### PR TITLE
Updated bitbucket_pattern to match dots

### DIFF
--- a/sublime_bucket.py
+++ b/sublime_bucket.py
@@ -203,7 +203,7 @@ class BackendBase():
         remotes = self.get_remote_list()
 
         for host in self.bitbucket_hosts:
-            bitbucket_pattern = (r'(?P<host>%s)[:/](?P<repo>[\w\-]+/[\w\-]+)'
+            bitbucket_pattern = (r'(?P<host>%s)[:/](?P<repo>[\w.\-]+/[\w.\-]+)'
                                  r'(?:\.git)?') % host
             for remote in remotes:
                 remote_match = re.search(bitbucket_pattern, remote)


### PR DESCRIPTION
I've started using this package and my repo has a dot in it's name. 
I've updated the regexp to match dots in repo name. 
Feel free to correct the regexp if needed, I'm not good at this :)