### PR TITLE
find_current_revision : ignore uncommited changes

### DIFF
--- a/sublime_bucket.py
+++ b/sublime_bucket.py
@@ -323,7 +323,8 @@ class MercurialBackend(BackendBase):
         return self._exec('hg paths').splitlines()
 
     def find_current_revision(self):
-        return self._exec('hg id -i').strip()
+        return self._exec('hg id -i').strip().split("+")[0]
+
 
     def find_selected_revision(self, file_path, current_line):
         annotated_lines = self._exec('hg annotate -c %s' % file_path).splitlines()


### PR DESCRIPTION
The command "hg id -i" will add a "+" sign if there are uncommited changes on local version. 
This implies a 404 on bitbucket server, so I've just removed this "+". 

There are many ways to do it, not sure this (.split("+")[0]) is your prefered way but seems to just work.